### PR TITLE
Choose working PHP box, fixing composer step

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: wercker/php
+box: perfectweb/development
 build:
   steps:
     - script:


### PR DESCRIPTION
I followed the "getting-started-php" notes online but the "box: wercker/php" fails to run composer from the command line.

Only wercker.yml is changed.

Wercker Support suggested using "box: php" but this did not easily allow the installation of composer as a CLI command. I found a reliable PHP box at hub.docker.com. I now use "box: perfectweb/development" and I have tested the build at wercker.com.
