### PR TITLE
Update Unit Test for PHP 7 and PHPUnit 6

### DIFF
--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,7 +1,8 @@
 <?php
+use PHPUnit\Framework\TestCase;
 use \Httpful\Request;
 
-class CitiesResponseTest extends PHPUnit_Framework_TestCase
+class CitiesResponseTest extends TestCase
 {
   public function testCitiesListContainsAmsterdam()
   {


### PR DESCRIPTION
The current box used by the build configuration is configured with PHP v7 and PHPUnit v6.  The test case was not correctly coded for these versions.